### PR TITLE
Use travis as CI service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: go
+
+go:
+  - 1.6
+  - 1.7
+  - 1.8.x
+  - master
+
+script: make test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # go-feature
 
+[![Build Status](https://travis-ci.org/spreadshirt/go-feature.svg?branch=master)](https://travis-ci.org/spreadshirt/go-feature)
+
 > Package feature provides a simple mechanism for creating and managing feature flags.
 
 See [./examples/hello](./examples/hello/hello.go) for an example.


### PR DESCRIPTION
This PR configures travis as continuous integration service and also adds a build status badge to the project's README.